### PR TITLE
Fix favorite stats function call

### DIFF
--- a/backend/src/routes/favoriteRoutes.js
+++ b/backend/src/routes/favoriteRoutes.js
@@ -95,7 +95,7 @@ router.get('/stats/summary', authMiddleware.verifyToken, async (req, res) => {
   try {
     const userId = req.userId;
     
-    const stats = await favoriteService.getFavoriteStats(userId);
+    const stats = await favoriteService.getUserFavoriteStats(userId);
     
     res.status(200).json(stats);
   } catch (error) {


### PR DESCRIPTION
## Summary
- use `getUserFavoriteStats` in favorite route

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683ce92110a483218d37e4bc133dd2b6