### PR TITLE
Fix circular dependency in telegram service

### DIFF
--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const authMiddleware = require('../middlewares/authMiddleware');
 const authService = require('../services/authService');
+const telegramApiService = require('../services/telegramApiService');
 
 // 添加Telegram账号
 router.post('/accounts', authMiddleware.verifyToken, async (req, res) => {
@@ -60,9 +61,8 @@ router.delete('/accounts/:accountId', authMiddleware.verifyToken, async (req, re
 router.post('/sync', authMiddleware.verifyToken, async (req, res) => {
   try {
     const userId = req.userId;
-    // 这里应该调用同步收藏的服务
-    // 简化处理，返回成功消息
-    res.status(200).json({ message: '同步成功' });
+    const result = await telegramApiService.syncUserFavorites(userId);
+    res.status(200).json(result);
   } catch (error) {
     console.error('同步收藏失败:', error);
     res.status(400).json({ message: error.message || '同步收藏失败' });

--- a/backend/src/services/authService.js
+++ b/backend/src/services/authService.js
@@ -422,6 +422,28 @@ const authService = {
       throw error;
     }
   },
+
+  // 更新用户设置
+  async updateUserSettings(userId, settings) {
+    try {
+      const user = await User.findById(userId);
+      if (!user) {
+        throw new Error('用户不存在');
+      }
+
+      user.settings = {
+        ...user.settings,
+        ...settings
+      };
+
+      await user.save();
+
+      return user.settings;
+    } catch (error) {
+      console.error('更新用户设置失败:', error.message, error.stack);
+      throw error;
+    }
+  },
   
   // 获取活跃Telegram账号的API凭证 (后端内部调用，例如同步功能)
   async getActiveAccountCredentials(userId) {

--- a/backend/src/services/telegramApiService.js
+++ b/backend/src/services/telegramApiService.js
@@ -13,9 +13,9 @@ const ffmpegPath = require('ffmpeg-static');
 const { TelegramClient } = require('telegram'); // <-- 确保这里是 'telegram'
 const { StringSession } = require('telegram/sessions'); // <-- 确保这里是 'telegram/sessions'
 
-// 导入 decryptSessionString 函数，用于解密 sessionString
-// 注意：这里只导入需要用到的 decryptSessionString 函数，避免循环依赖问题
-const { decryptSessionString } = require('./authService');
+// 直接导入完整的 authService，避免在模块加载顺序导致的循环依赖问题
+// 通过 authService.decryptSessionString 调用解密函数
+const authService = require('./authService');
 
 
 // 设置ffmpeg路径
@@ -227,7 +227,9 @@ const telegramApiService = {
       }
 
       // 解密 SESSION_STRING
-      const sessionString = decryptSessionString(activeAccount.sessionString);
+      const sessionString = authService.decryptSessionString(
+        activeAccount.sessionString
+      );
 
       // 初始化 Telegram 客户端
       client = new TelegramClient(new StringSession(sessionString), parseInt(activeAccount.apiId), activeAccount.apiHash, {


### PR DESCRIPTION
## Summary
- load the whole auth service in `telegramApiService` to avoid circular imports
- call `authService.decryptSessionString` when syncing favorites

## Testing
- `npm test` (backend) – failed: missing script
- `npm run lint` (backend) – failed: missing script
- `npm test` (frontend) – failed: missing script
- `npm run lint` (frontend) – failed: `vue-cli-service` not found

------
https://chatgpt.com/codex/tasks/task_b_683d1fe0173883218d791cd53422cdb1